### PR TITLE
Jellyfin 10.8 fixes

### DIFF
--- a/InfuseSync/InfuseSync.Emby.csproj
+++ b/InfuseSync/InfuseSync.Emby.csproj
@@ -8,8 +8,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>1.5.0</AssemblyVersion>
-    <FileVersion>1.5.0</FileVersion>
+    <AssemblyVersion>1.4.1</AssemblyVersion>
+    <FileVersion>1.4.1</FileVersion>
     <RootNamespace>InfuseSync</RootNamespace>
     <AssemblyName>InfuseSync</AssemblyName>
     <DefineConstants>EMBY</DefineConstants>

--- a/InfuseSync/InfuseSync.Emby.csproj
+++ b/InfuseSync/InfuseSync.Emby.csproj
@@ -8,8 +8,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>1.4.1</AssemblyVersion>
-    <FileVersion>1.4.1</FileVersion>
+    <AssemblyVersion>1.5.0</AssemblyVersion>
+    <FileVersion>1.5.0</FileVersion>
     <RootNamespace>InfuseSync</RootNamespace>
     <AssemblyName>InfuseSync</AssemblyName>
     <DefineConstants>EMBY</DefineConstants>

--- a/InfuseSync/InfuseSync.Jellyfin.csproj
+++ b/InfuseSync/InfuseSync.Jellyfin.csproj
@@ -8,8 +8,8 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <AssemblyVersion>1.5.0</AssemblyVersion>
-    <FileVersion>1.5.0</FileVersion>
+    <AssemblyVersion>1.4.1</AssemblyVersion>
+    <FileVersion>1.4.1</FileVersion>
     <RootNamespace>InfuseSync</RootNamespace>
     <AssemblyName>InfuseSync</AssemblyName>
     <DefineConstants>JELLYFIN</DefineConstants>

--- a/InfuseSync/InfuseSync.Jellyfin.csproj
+++ b/InfuseSync/InfuseSync.Jellyfin.csproj
@@ -7,9 +7,9 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <AssemblyVersion>1.4.1</AssemblyVersion>
-    <FileVersion>1.4.1</FileVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyVersion>1.5.0</AssemblyVersion>
+    <FileVersion>1.5.0</FileVersion>
     <RootNamespace>InfuseSync</RootNamespace>
     <AssemblyName>InfuseSync</AssemblyName>
     <DefineConstants>JELLYFIN</DefineConstants>
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
-    <PackageReference Include="SQLitePCL.pretty.netstandard" Version="2.1.0" />
+    <PackageReference Include="SQLitePCL.pretty.netstandard" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 

--- a/InfuseSync/Plugin.cs
+++ b/InfuseSync/Plugin.cs
@@ -29,7 +29,11 @@ namespace InfuseSync
             IApplicationPaths applicationPaths,
             IXmlSerializer xmlSerializer,
             ILogger logger,
+#if EMBY
             IJsonSerializer serializer) : base(applicationPaths, xmlSerializer)
+#else
+            IXmlSerializer serializer) : base(applicationPaths, xmlSerializer)
+#endif
         {
             Instance = this;
 

--- a/InfuseSync/ScheduledTasks/HousekeepingTask.cs
+++ b/InfuseSync/ScheduledTasks/HousekeepingTask.cs
@@ -36,8 +36,11 @@ namespace InfuseSync.ScheduledTasks
                 }
             };
         }
-
+#if EMBY
         public Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
+#else
+        public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+#endif
         {
             var expirationDays = Plugin.Instance.Configuration.CacheExpirationDays;
             if (expirationDays == 0) {

--- a/InfuseSync/Storage/Db.cs
+++ b/InfuseSync/Storage/Db.cs
@@ -19,10 +19,15 @@ namespace InfuseSync.Storage
         private const string CheckpointsTable = "checkpoints";
         private const string ItemsTable = "items";
         private const string UserInfoTable = "user_info";
-
+#if EMBY
         private readonly IJsonSerializer _serializer;
 
         public Db(string path, ILogger logger, IJsonSerializer jsonSerializer) : base(logger)
+#else
+        private readonly IXmlSerializer _serializer;
+
+        public Db(string path, ILogger logger, IXmlSerializer jsonSerializer) : base(logger)
+#endif
         {
             _serializer = jsonSerializer;
             Directory.CreateDirectory(path);

--- a/InfuseSync/Storage/ManagedConnection.cs
+++ b/InfuseSync/Storage/ManagedConnection.cs
@@ -48,12 +48,12 @@ namespace InfuseSync.Storage
             return db.RunInTransaction(action, mode);
         }
 
-        public IEnumerable<IReadOnlyList<IResultSetValue>> Query(string sql)
+        public IEnumerable<IReadOnlyList<ResultSetValue>> Query(string sql)
         {
             return db.Query(sql);
         }
 
-        public IEnumerable<IReadOnlyList<IResultSetValue>> Query(string sql, params object[] values)
+        public IEnumerable<IReadOnlyList<ResultSetValue>> Query(string sql, params object[] values)
         {
             return db.Query(sql, values);
         }

--- a/InfuseSync/Storage/SqliteExtensions.cs
+++ b/InfuseSync/Storage/SqliteExtensions.cs
@@ -5,7 +5,7 @@ using SQLitePCL.pretty;
 #if EMBY
 using ResultSet = SQLitePCL.pretty.IResultSet;
 #else
-using ResultSet = System.Collections.Generic.IReadOnlyList<SQLitePCL.pretty.IResultSetValue>;
+using ResultSet = System.Collections.Generic.IReadOnlyList<SQLitePCL.pretty.ResultSetValue>;
 #endif
 
 namespace InfuseSync.Storage
@@ -84,32 +84,32 @@ namespace InfuseSync.Storage
         }
 
 #if JELLYFIN
-        public static bool IsDBNull(this IReadOnlyList<IResultSetValue> result, int index)
+        public static bool IsDBNull(this IReadOnlyList<ResultSetValue> result, int index)
         {
             return result[index].SQLiteType == SQLiteType.Null;
         }
 
-        public static string GetString(this IReadOnlyList<IResultSetValue> result, int index)
+        public static string GetString(this IReadOnlyList<ResultSetValue> result, int index)
         {
             return result[index].ToString();
         }
 
-        public static bool GetBoolean(this IReadOnlyList<IResultSetValue> result, int index)
+        public static bool GetBoolean(this IReadOnlyList<ResultSetValue> result, int index)
         {
             return result[index].ToBool();
         }
 
-        public static int GetInt(this IReadOnlyList<IResultSetValue> result, int index)
+        public static int GetInt(this IReadOnlyList<ResultSetValue> result, int index)
         {
             return result[index].ToInt();
         }
 
-        public static long GetInt64(this IReadOnlyList<IResultSetValue> result, int index)
+        public static long GetInt64(this IReadOnlyList<ResultSetValue> result, int index)
         {
             return result[index].ToInt64();
         }
 
-        public static float GetFloat(this IReadOnlyList<IResultSetValue> result, int index)
+        public static float GetFloat(this IReadOnlyList<ResultSetValue> result, int index)
         {
             return result[index].ToFloat();
         }


### PR DESCRIPTION
Updated for compatibility with Jellyfin 10.8. Seems to be working on my local Jellyfin installation. Should be built with version 10.8.0-beta1 of Jellyfin.Controller and Jellyfin.Model.

Fixes #12 