### PR TITLE
Add support for Jellyfin 12 (RC4)

### DIFF
--- a/InfuseSync/API/InfuseSyncService.cs
+++ b/InfuseSync/API/InfuseSyncService.cs
@@ -268,7 +268,12 @@ namespace InfuseSync.API
             var items = GetUserItems(user, itemsUpdated);
 
             var options = new DtoOptions { Fields = request.GetItemFields() };
-            var itemDtos = _dtoService.GetBaseItemDtos(items, options, user);
+            var itemDtos = _dtoService.GetBaseItemDtos(
+                items,
+                options,
+                user,
+                owner: null,
+                skipVisibilityCheck: false);
 
             return new QueryResult<BaseItemDto> {
                 Items = itemDtos,

--- a/InfuseSync/InfuseSync.Jellyfin.csproj
+++ b/InfuseSync/InfuseSync.Jellyfin.csproj
@@ -7,7 +7,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyVersion>1.5.2</AssemblyVersion>
     <FileVersion>1.5.2</FileVersion>
     <RootNamespace>InfuseSync</RootNamespace>
@@ -16,9 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.*-*" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.6" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0-rc4" />
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0-rc4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## what this fixes

InfuseSync 1.5.2 works with Jellyfin 10.11, but the current Jellyfin build is not compatible with Jellyfin 12.0.0 RC4.

the plugin itself still loads, so at first it looks fine. the problem appears when Infuse starts an incremental sync. `StartSync` returns 200, but the following `UpdatedItems` requests fail with HTTP 500 and Jellyfin logs a `MissingMethodException`.

the cause is the Jellyfin 12 API change around `IDtoService.GetBaseItemDtos`. Jellyfin 12 also moved to .NET 10, and the method now includes the `skipVisibilityCheck` parameter, so the call compiled for Jellyfin 10.11 no longer matches what Jellyfin 12 RC4 exposes at runtime.

## changes

- move the Jellyfin project from .NET 9 to .NET 10
- update the Jellyfin Controller and Model references to `12.0.0-rc4`
- update `Microsoft.Data.Sqlite` to the .NET 10 version used by this build
- update the `GetBaseItemDtos` call for the Jellyfin 12 RC4 API
- keep visibility checks enabled with `skipVisibilityCheck: false`

I kept the plugin version at 1.5.2 on purpose. this PR is only about Jellyfin 12 RC4 compatibility, so I prefer to leave the release/version bump to the maintainer if this gets merged.

## testing

I tested the patched Jellyfin plugin directly on my server with:

- Jellyfin 12.0.0 RC4 in Docker
- Infuse 8.5 on tvOS
- tvOS 26.6
- Apple TV 4K 3rd generation, Wi-Fi + Ethernet, 128 GB, model A2843 / `AppleTV14,1`

before installing the patched DLL, the sync sequence looked like this:

- `StartSync` -> HTTP 200
- `UpdatedItems` -> HTTP 500
- Jellyfin logs -> `MissingMethodException`

after installing the patched DLL:

- `StartSync` -> HTTP 200
- `UpdatedItems` -> HTTP 200
- Series -> HTTP 200
- Season -> HTTP 200
- Movie / Episode / Video / MusicVideo -> HTTP 200, including pagination
- Folder -> HTTP 200
- RemovedItems -> HTTP 200
- UserData -> HTTP 200
- CollectionFolder -> HTTP 200

the full incremental sync then completed normally in Infuse and I could no longer reproduce the previous `MissingMethodException`.

I also checked the build side with the .NET 10 SDK. restore, Release publish and plugin DLL generation all complete successfully.

CI run:
https://github.com/hakito73/InfuseSync/actions/runs/31003228773

## note about stable Jellyfin 12

this PR is intentionally tested and pinned against Jellyfin `12.0.0-rc4` because that is the version available and tested here right now.

when Jellyfin 12 stable is released, the package references should be checked again against the stable Jellyfin API before assuming the RC4 build is still compatible.